### PR TITLE
Changing workflow to disable reservation feature for company users

### DIFF
--- a/src/Controller/ReservationController.php
+++ b/src/Controller/ReservationController.php
@@ -30,6 +30,11 @@ class ReservationController extends AbstractController
     #[Route('/reservation/new/{id}', name: 'make_reservation')]
     public function new(Request $request, SportCompany $company, ReservationRepository $reservationRepository): Response
     {
+        $user = $this->getUser();
+        if(in_array('ROLE_COMPANY', $user->getRoles())){
+            return $this->redirectToRoute('home');
+        }
+
         if($request->isMethod('POST')){
             $reservationData = $request->request->all();
 

--- a/templates/pages/home.html.twig
+++ b/templates/pages/home.html.twig
@@ -66,7 +66,9 @@
             <span class="venue-price">A partir de {{ company.services[0].price ?? 'N/A' }}€</span>
             <div class="action-buttons">
                 <a href="{{ path('company_details', {'id': company.id}) }}" class="btn-details">Voir Details</a>
-                <a href="{{ path('make_reservation', {'id': company.id}) }}" class="btn-book">Réserver</a>
+                {% if not is_granted('ROLE_COMPANY') %}
+                    <a href="{{ path('make_reservation', {'id': company.id}) }}" class="btn-book">Réserver</a>
+                {% endif %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
Changes to prevent a bug (might be changing the logic later to prevent any bug linked to this solve)

- Modified src/Controller/ReservationController.php to redirect the company user to the home page when trying to access the reservation page
- Modified templates/pages/home.html.twig to hide the reservation button on the display when logged as a company
